### PR TITLE
feat: add `--view-key` to view and create ssh key

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,25 +72,17 @@ flowchart RL
 ### Setup on host device
 
 First, configure your `~/.ssh/config` or `/etc/ssh-tunnel/ssh-tunnel.config` to
-contain the username and hostname of the SSH server:
+contain the username and hostname of the SSH server. Or, just copy the contents
+of the included [`ssh-tunnel.config`](./ssh-tunnel.config).
 
 ```conf
 Host nqminds-iot-hub-ssh-control
-        HostName ec2-34-251-158-148.eu-west-1.compute.amazonaws.com # change this
-        User ssh-tunnel # change this
+        HostName ec2-34-251-158-148.eu-west-1.compute.amazonaws.com
+        User ssh-tunnel
 ```
 
-Next, if you do not have a public key configured (e.g. `ls ~/.ssh/*.pub` returns no such file),
-then you can create a passphrase-less key with:
-
-```bash
-if [ ! -f ~/.ssh/id_ed25519 ]; then
-	ssh-keygen -t ed25519 -N "" -C "$(id -u -n)@$(uname -n)" -f ~/.ssh/id_ed25519
-fi
-```
-
-Next, copy your public key from `cat ~/.ssh/id_ed25519.pub` and add it to the
-`~/.ssh/authorized_keys` file on the server (see below).
+Next, run `./ssh-tunnel --view-key --check`. This will output your `~/.ssh/id_ed25519.pub` public key, creating it if it does not exist. You can then
+add it to the `~/.ssh/authorized_keys` file on the server (see below).
 
 Finally, you can run the following command to create the SSH tunnel:
 

--- a/ssh-tunnel
+++ b/ssh-tunnel
@@ -95,10 +95,21 @@ function ssh-tunnel() {
   done
 }
 
+function view-key() {
+  if [ ! -f ~/.ssh/id_ed25519 ]; then
+    ssh-keygen -t ed25519 -N "" -C "$(id -u -n)@$(uname -n)" -f ~/.ssh/id_ed25519
+  fi
+  reset='\033[0m'       # Text Reset
+  cyan='\033[0;36m'         # Cyan
+  echo -e "${cyan}Info: Ouputing ~/.ssh/id_ed25519.pub, please add to your server's ~/.ssh/authorized_keys file.${reset}" >&2
+  cat ~/.ssh/id_ed25519.pub
+}
+
 destination=nqminds-iot-hub-ssh-control
 config="/etc/ssh-tunnel/ssh-tunnel.config"
 host_port=22
 check=0
+view_key=0
 
 help_text="Usage: $(basename "$0") [OPTIONS] [DESTINATION]
 
@@ -125,6 +136,8 @@ Options:
   --check:           Checks to see if SSH can be used to connect to the target.
                      Creates a file called '~/connections/<hostname>.test' to check
                      for permission errors.
+  --view-key         Outputs the ~/.ssh/id_ed25519.pub.
+                     Creates the file if it does not already exist.
   -c, --config:      Specify a custom ssh_config file.
                      Defaults to $config.
                      Ignored if this file doesn't exist or cannot be read.
@@ -135,7 +148,7 @@ showHelp() {
   echo 2>&1 "$help_text"
 }
 
-options=$(getopt -l "help,destination:,check,config:,host-port:" -o "h,d:,P:" -- "$@")
+options=$(getopt -l "help,destination:,check,config:,host-port:,view-key" -o "h,d:,P:" -- "$@")
 eval set -- "$options"
 
 while [ "$1" ]; do
@@ -168,6 +181,9 @@ case $1 in
     fi
     shift
     ;;
+--view-key)
+    view_key=1
+    ;;
 --)
     shift
     break;;
@@ -183,10 +199,15 @@ done
 export destination="${destination}"
 export config="$config"
 
+if [ "$view_key" -ne 0 ]; then
+  view-key
+fi
+
 if [ "$check" -ne 0 ]; then
   ssh-check
   exit "$?"
 fi
+
 ssh-tunnel
 
 echo 2>&1 "$(basename "$0") --destination ${destination} failed"


### PR DESCRIPTION
In #23, @mereacre asked for:

  - some way to generate hostname
    (skipped, already included in file [`ssh-tunnel.config`](./https://github.com/nqminds/nqm-ssh-tunnel/blob/master/ssh-tunnel.config), installed to `/etc/ssh-tunnel/ssh-tunnel.config` on Debian)
    - I feel like this isn't needed, and this PR can close #23, since it's already setup by default on Debian. And I can set it up for OpenWRT too.
  - some way to generate ~/.ssh/id_ed25519
    (this PR will allow generating it with `ssh-tunnel --view-key`, if it does not exist)
  - some way to view ~/.ssh/id_ed25519.pub
    (this PR will allow viewing it with `ssh-tunnel --view-key`)


