### PR TITLE
ci: add pre-commit lint action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,13 @@ on:
 name: Build
 
 jobs:
+  lint:
+    name: Lint
+    runs-on: [ubuntu-20.04]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v3
+      - uses: pre-commit/action@v3.0.0
   build-deb:
     name: Build Debian Package
     # building a deb is super slow, but we're a public repo now, so it's free!!


### PR DESCRIPTION
Adds a pre-commit linting action.

I wanted to use https://pre-commit.ci/ but I got a bit scared of the app permissions it requested for my GitHub account.