### PR TITLE
ci: fix broken pre-commit check on `main`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,9 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v3
       - uses: pre-commit/action@v3.0.0
+        with:
+          # skip the check that throws on `main` branch
+          SKIP: no-commit-to-branch
   build-deb:
     name: Build Debian Package
     # building a deb is super slow, but we're a public repo now, so it's free!!


### PR DESCRIPTION
We have a `pre-commit` action that checks to make sure people don't accidentally commit to `master`/`main` (I occasionally do it because I forget which branch I'm on).

We have to make sure that the CI doesn't run this on the `main`/`master` branch however.