### PR TITLE
ci: add a GitHub Actions test to test whether the deb works

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,9 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+      - name: Make cache dir
+        # needed because otherwise actions/cache throws a permission error
+        run: sudo mkdir --mode a=rwx --parents /var/cache/pbuilder
       - name: Cache pbuilder base
         id: cache-pbuilder-base
         uses: actions/cache@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -96,3 +96,41 @@ jobs:
                 console.error(`[skipped] Uploading ${basename(filePath)} failed: ${error}`);
               }
             }
+  test-deb:
+    name: Test Debian Package
+    needs: build-deb
+    runs-on: [ubuntu-20.04]
+    steps:
+      - uses: actions/download-artifact@v2
+        with:
+          name: built-debs
+      - name: Install ssh-tunnel from .deb
+        run: |
+          sudo apt-get install ./ssh-tunnel_*_all.deb -y
+      - name: Create config
+        env:
+          ssh_tunnel_config: |
+            Host ssh-server
+              Port 2222
+              HostName localhost
+              User linuxserver.io
+              IdentityFile ./key_from_github
+              StrictHostKeyChecking=no
+        run: |
+          ssh-keygen -t ed25519 -N "" -C "$(id -u -n)@$(uname -n)" -f key_from_github
+          echo "${ssh_tunnel_config}" > local-ssh-tunnel.config
+      - name: Run Local SSH Server in background
+        id: start-podman-ssh-server
+        run: |
+          podman stop reverse-ssh-tunnel-server || true
+          podman run --rm --detach \
+            --name=reverse-ssh-tunnel-server \
+            --publish 2222:2222 \
+            --env PUBLIC_KEY="$(cat ./key_from_github.pub)" \
+            lscr.io/linuxserver/openssh-server:latest
+      - name: Run SSH-Tunnel check
+        run: |
+          ssh-tunnel --check --config local-ssh-tunnel.config --destination ssh-server
+      - name: Stop Podman SSH Server
+        if: ${{ always() && steps.start-podman-ssh-server.conclusion == 'success' }}
+        run: podman stop reverse-ssh-tunnel-server

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -128,6 +128,9 @@ jobs:
             --publish 2222:2222 \
             --env PUBLIC_KEY="$(cat ./key_from_github.pub)" \
             lscr.io/linuxserver/openssh-server:latest
+          # linuxserver/openssh-server doesn't have a healthcheck command
+          # so we just wait a few seconds for the server to start
+          sleep 5
       - name: Run SSH-Tunnel check
         run: |
           ssh-tunnel --check --config local-ssh-tunnel.config --destination ssh-server

--- a/ssh-tunnel
+++ b/ssh-tunnel
@@ -158,7 +158,6 @@ case $1 in
     ;;
 --check)
     check=1
-    shift
     ;;
 --config)
     if [ -r "$2" ]; then


### PR DESCRIPTION
Adds a basic test for the `ssh-tunnel` shell script.

It works by creating an SSH server on the CI runner, then checking to see whether the `--check` command works on it.

It's not a full test, but it's better than nothing!
