### PR TITLE
ci: fix incorrect SKIP var for pre-commit

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v3
       - uses: pre-commit/action@v3.0.0
-        with:
+        env:
           # skip the check that throws on `main` branch
           SKIP: no-commit-to-branch
   build-deb:


### PR DESCRIPTION
I accidentally put down `SKIP` as a `with:` var, not an `env:` var.

Fixes https://github.com/nqminds/nqm-ssh-tunnel/commit/957ebfff3802931900c4b2bc0ef44cb203ba6ee0