### PR TITLE
refactor!: rename project to ssh-legion

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -114,9 +114,9 @@ jobs:
       - uses: actions/download-artifact@v2
         with:
           name: built-debs
-      - name: Install ssh-tunnel from .deb
+      - name: Install ssh-legion from .deb
         run: |
-          sudo apt-get install ./ssh-tunnel_*_all.deb -y
+          sudo apt-get install ./ssh-legion_*_all.deb -y
       - name: Create config
         env:
           ssh_tunnel_config: |
@@ -128,22 +128,22 @@ jobs:
               StrictHostKeyChecking=no
         run: |
           ssh-keygen -t ed25519 -N "" -C "$(id -u -n)@$(uname -n)" -f key_from_github
-          echo "${ssh_tunnel_config}" > local-ssh-tunnel.config
+          echo "${ssh_tunnel_config}" > local-ssh-legion.config
       - name: Run Local SSH Server in background
         id: start-podman-ssh-server
         run: |
-          podman stop reverse-ssh-tunnel-server || true
+          podman stop reverse-ssh-legion-server || true
           podman run --rm --detach \
-            --name=reverse-ssh-tunnel-server \
+            --name=reverse-ssh-legion-server \
             --publish 2222:2222 \
             --env PUBLIC_KEY="$(cat ./key_from_github.pub)" \
             lscr.io/linuxserver/openssh-server:latest
           # linuxserver/openssh-server doesn't have a healthcheck command
           # so we just wait a few seconds for the server to start
           sleep 5
-      - name: Run SSH-Tunnel check
+      - name: Run ssh-legion check
         run: |
-          ssh-tunnel --check --config local-ssh-tunnel.config --destination ssh-server
+          ssh-legion --check --config local-ssh-legion.config --destination ssh-server
       - name: Stop Podman SSH Server
         if: ${{ always() && steps.start-podman-ssh-server.conclusion == 'success' }}
-        run: podman stop reverse-ssh-tunnel-server
+        run: podman stop reverse-ssh-legion-server

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ through the reverse SSH tunnel to the host.
 
 Importantly, each host creates a file on the server's `~/connections` folder
 that contains the port number of the local tunnel port. This means that you
-can deploy this `ssh-tunnel` script on multiple devices, and have them all
+can deploy this `ssh-legion` script on multiple devices, and have them all
 use unique ports automatically.
 
 ## Contents
@@ -71,24 +71,24 @@ flowchart RL
 
 ### Setup on host device
 
-First, configure your `~/.ssh/config` or `/etc/ssh-tunnel/ssh-tunnel.config` to
+First, configure your `~/.ssh/config` or `/etc/ssh-legion/ssh-legion.config` to
 contain the username and hostname of the SSH server. Or, just copy the contents
-of the included [`ssh-tunnel.config`](./ssh-tunnel.config).
+of the included [`ssh-legion.config`](./ssh-legion.config).
 
 ```conf
 Host nqminds-iot-hub-ssh-control
         HostName ec2-34-251-158-148.eu-west-1.compute.amazonaws.com
-        User ssh-tunnel
+        User ssh-legion
 ```
 
-Next, run `./ssh-tunnel --view-key --check`. This will output your `~/.ssh/id_ed25519.pub` public key, creating it if it does not exist. You can then
+Next, run `./ssh-legion --view-key --check`. This will output your `~/.ssh/id_ed25519.pub` public key, creating it if it does not exist. You can then
 add it to the `~/.ssh/authorized_keys` file on the server (see below).
 
 Finally, you can run the following command to create the SSH tunnel:
 
 ```bash
-./ssh-tunnel --check # checks to see if the SSH tunnel works
-./ssh-tunnel # creates the SSH tunnel (use --destination to specify the server)
+./ssh-legion --check # checks to see if the SSH tunnel works
+./ssh-legion # creates the SSH tunnel (use --destination to specify the server)
 ```
 
 ### Setup on reverse SSH server
@@ -103,7 +103,7 @@ If the file does not exist, you can create it.
 We highly recommned that you lockdown the reverse SSH server, as reverse SSHers
 only need minimal permissions.
 
-See [./doc/ssh-tunnel-server.md](./doc/ssh-tunnel-server.md) on the recommended
+See [./doc/ssh-legion-server.md](./doc/ssh-legion-server.md) on the recommended
 security practices.
 
 ### Connecting from your client device
@@ -113,11 +113,11 @@ in the home directory of the SSH tunnel user.
 
 Each file will have the name of a connected reverse SSH host, of format `<username>@<hostname>:<port>`.
 
-For example, assuming the reverse SSH tunnel is using the username `ssh-tunnel`,
+For example, assuming the reverse SSH tunnel is using the username `ssh-legion`,
 you can find all the connections by doing:
 
 ```console
-ubuntu@nqminds-iot-hub-ssh-control $ ls /home/ssh-tunnel/connections/
+ubuntu@nqminds-iot-hub-ssh-control $ ls /home/ssh-legion/connections/
 alexandru@dazzling-dream:48106
 ```
 
@@ -148,7 +148,7 @@ and checking that the reverse SSH tunnel actually exists.
 
 ### OS specific instructions
 
-To build `ssh-tunnel` for specific operating systems, see [Building packages](./doc/Building-packages.md)
+To build `ssh-legion` for specific operating systems, see [Building packages](./doc/Building-packages.md)
 
 For OS specific usage instructions, see:
 

--- a/debian/README.md
+++ b/debian/README.md
@@ -13,18 +13,18 @@ First, make sure it's enabled with:
 sudo loginctl enable-linger "$(whoami)"
 ```
 
-Then, you can start ssh-tunnel without `sudo` using:
+Then, you can start ssh-legion without `sudo` using:
 
 ```bash
-systemctl --user start ssh-tunnel.service
-# systemctl --user enable ssh-tunnel.service to auto run on startup
+systemctl --user start ssh-legion.service
+# systemctl --user enable ssh-legion.service to auto run on startup
 ```
 
-If you want to start an ssh-tunnel to another server, make sure to add
-the server to `/etc/ssh-tunnel/ssh-tunnel.config` or `~/.ssh/config`, then run
+If you want to start an ssh-legion to another server, make sure to add
+the server to `/etc/ssh-legion/ssh-legion.config` or `~/.ssh/config`, then run
 
 ```bash
-systemctl --user start ssh-tunnel@the-name-of-your-server-here.service
+systemctl --user start ssh-legion@the-name-of-your-server-here.service
 ```
 
 ### Viewing logs
@@ -33,14 +33,14 @@ If you ever want to view the logs of the reverse SSH service, you can do this
 via:
 
 ```bash
-journalctl --user -u ssh-tunnel.service
+journalctl --user -u ssh-legion.service
 ```
 
 `journalctl` has the `-f` flag to watch the live logs of a service, that
 may be useful in debugging:
 
 ```bash
-journalctl --user -fu ssh-tunnel.service
+journalctl --user -fu ssh-legion.service
 ```
 
 ### Stopping/disabling the service
@@ -51,11 +51,11 @@ the service by using `systemctl --user`. Example:
 **To stop the service**
 
 ```bash
-systemctl --user stop ssh-tunnel.service
+systemctl --user stop ssh-legion.service
 ```
 
 **To disable the service from running on the next boot**
 
 ```bash
-systemctl --user disable ssh-tunnel.service
+systemctl --user disable ssh-legion.service
 ```

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-ssh-tunnel (0.1.0) UNRELEASED; urgency=low
+ssh-legion (0.1.0) UNRELEASED; urgency=low
 
   * Initial release.
 

--- a/debian/control
+++ b/debian/control
@@ -1,14 +1,14 @@
-Source: ssh-tunnel
+Source: ssh-legion
 Section: net
 Priority: optional
 Maintainer: Alois Klink <alois@nquiringminds.com>
 Build-Depends: debhelper-compat (= 12)
 Standards-Version: 4.5.0
-Homepage: https://github.com/nqminds/nqm-ssh-tunnel
-Vcs-Browser: https://github.com/nqminds/nqm-ssh-tunnel
-Vcs-Git: https://github.com/nqminds/nqm-ssh-tunnel.git
+Homepage: https://github.com/nqminds/nqm-ssh-legion
+Vcs-Browser: https://github.com/nqminds/nqm-ssh-legion
+Vcs-Git: https://github.com/nqminds/nqm-ssh-legion.git
 
-Package: ssh-tunnel
+Package: ssh-legion
 Architecture: all
 Depends:
  openssh-client,

--- a/debian/copyright
+++ b/debian/copyright
@@ -1,7 +1,7 @@
 Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
-Upstream-Name: nqm-ssh-tunnel
+Upstream-Name: nqm-ssh-legion
 Upstream-Contact: Alois Klink <alois@nquiringminds.com>
-Source: https://github.com/nqminds/nqm-ssh-tunnel
+Source: https://github.com/nqminds/nqm-ssh-legion
 
 Files: *
 Copyright: 2019-2022, NquiringMinds Ltd.

--- a/debian/install
+++ b/debian/install
@@ -1,2 +1,2 @@
-ssh-tunnel usr/bin
-ssh-tunnel.config etc/ssh-tunnel
+ssh-legion usr/bin
+ssh-legion.config etc/ssh-legion

--- a/debian/ssh-legion.user.config
+++ b/debian/ssh-legion.user.config
@@ -15,7 +15,7 @@ StartLimitBurst=3
 
 Type=simple
 
-ExecStart=/usr/bin/ssh-tunnel --destination %i
+ExecStart=/usr/bin/ssh-legion --destination %i
 
 # try to restart and find an SSH connection
 # restarts until StartLimits are hit

--- a/debian/ssh-legion@.user.config
+++ b/debian/ssh-legion@.user.config
@@ -1,0 +1,1 @@
+ssh-legion.user.config

--- a/debian/ssh-tunnel@.user.service
+++ b/debian/ssh-tunnel@.user.service
@@ -1,1 +1,0 @@
-./ssh-tunnel.user.service

--- a/doc/ssh-tunnel-server.md
+++ b/doc/ssh-tunnel-server.md
@@ -2,24 +2,24 @@
 
 Recommended secure config for the Nquiringminds's SSH Tunnel Server.
 
-The following instructions creates a new user called `ssh-tunnel` on your server.
-A chroot jail is then created at `/home/ssh-tunnel/chroot-jail` containing
-only the files required for the ssh-tunnel script to work.
+The following instructions creates a new user called `ssh-legion` on your server.
+A chroot jail is then created at `/home/ssh-legion/chroot-jail` containing
+only the files required for the ssh-legion script to work.
 
 Finally, the `/etc/ssh/sshd_config` SSH config is modified so that ssh-ing
-into the `ssh-tunnel` will always lead into the Chroot Jail.
+into the `ssh-legion` will always lead into the Chroot Jail.
 
 ### Create Chroot Jail
 
 ```bash
-# creates /home/ssh-tunnel
-sudo adduser --system ssh-tunnel --shell /usr/bin/bash
-sudo -u ssh-tunnel mkdir --parents /home/ssh-tunnel/.ssh
-chroot="/home/ssh-tunnel/chroot-jail"
+# creates /home/ssh-legion
+sudo adduser --system ssh-legion --shell /usr/bin/bash
+sudo -u ssh-legion mkdir --parents /home/ssh-legion/.ssh
+chroot="/home/ssh-legion/chroot-jail"
 # The path to the chroot-jail must be owned by root
-sudo chown root:root /home/ssh-tunnel
-sudo -u ssh-tunnel touch /home/ssh-tunnel/.ssh/authorized_keys
-sudo -u ssh-tunnel chmod 600 /home/ssh-tunnel/.ssh/authorized_keys
+sudo chown root:root /home/ssh-legion
+sudo -u ssh-legion touch /home/ssh-legion/.ssh/authorized_keys
+sudo -u ssh-legion chmod 600 /home/ssh-legion/.ssh/authorized_keys
 
 function create_chroot_jail() {
     chroot_folder="$1"
@@ -29,11 +29,11 @@ function create_chroot_jail() {
         exit 1
     fi
 
-    sudo mkdir --parents "$chroot"/{dev,usr/bin,lib/x86_64-linux-gnu,lib64,home/ssh-tunnel/connections}
+    sudo mkdir --parents "$chroot"/{dev,usr/bin,lib/x86_64-linux-gnu,lib64,home/ssh-legion/connections}
     # chroot jail must be owned by root
     sudo chown --recursive root:root "$chroot"
     sudo chmod 0755 "$chroot"
-    sudo chown --recursive ssh-tunnel "$chroot"/home/ssh-tunnel/connections
+    sudo chown --recursive ssh-legion "$chroot"/home/ssh-legion/connections
 
     function copy_symlinks_to_file() {
         file="$1"
@@ -67,11 +67,11 @@ function create_chroot_jail() {
     sudo mknod "$chroot/dev/tty"  c 5 0
     sudo chmod 0666 "$chroot"/dev/{null,tty,zero}
     sudo chown root.tty "$chroot"/dev/tty
-    # sudo mount -t devtmpfs none /home/ssh-tunnel/chroot-jail/dev
+    # sudo mount -t devtmpfs none /home/ssh-legion/chroot-jail/dev
 }
 
 create_chroot_jail "$chroot"
-ln -s "$chroot"/home/ssh-tunnel/connections /home/ssh-tunnel/connections
+ln -s "$chroot"/home/ssh-legion/connections /home/ssh-legion/connections
 ```
 
 ### `/etc/ssh/sshd_config` config
@@ -81,6 +81,6 @@ Then, add the following file to your `/etc/ssh/sshd_config` file:
 ```conf
 # warning, this does not work from /etc/ssh/sshd_config/*.conf
 # in OpenSSH <= 8.4, see https://bugzilla.mindrot.org/show_bug.cgi?id=3122
-Match User ssh-tunnel
+Match User ssh-legion
     ChrootDirectory %h/chroot-jail
 ```

--- a/ssh-legion
+++ b/ssh-legion
@@ -18,7 +18,7 @@ function ssh-check() {
   ssh "${ssh_options[@]}" "${destination}" 'mkdir -p ~/connections && touch ~/connections/'"${MYNAME}.test"
 }
 
-function ssh-tunnel() {
+function ssh-legion() {
   MACHINE_ID=$(cat /var/lib/dbus/machine-id || true)
   if [ -z "$MACHINE_ID" ]; then
     mac="$(cat /sys/class/net/*/address | head -1)"
@@ -106,7 +106,7 @@ function view-key() {
 }
 
 destination=nqminds-iot-hub-ssh-control
-config="/etc/ssh-tunnel/ssh-tunnel.config"
+config="/etc/ssh-legion/ssh-legion.config"
 host_port=22
 check=0
 view_key=0
@@ -207,8 +207,8 @@ if [ "$check" -ne 0 ]; then
   exit "$?"
 fi
 
-ssh-tunnel
+ssh-legion
 
 echo 2>&1 "$(basename "$0") --destination ${destination} failed"
-# always return failure since ssh-tunnel should never end
+# always return failure since ssh-legion should never end
 exit 1

--- a/ssh-legion.config
+++ b/ssh-legion.config
@@ -2,7 +2,7 @@
 
 Host nqminds-iot-hub-ssh-control
         HostName ec2-34-251-158-148.eu-west-1.compute.amazonaws.com
-        User ssh-tunnel
+        User ssh-legion
         Port 22
         # Check connection every 15 seconds to see if connection is alive
         ServerAliveInterval 15


### PR DESCRIPTION
ssh-tunnel is quite generic and may conflict easily with some pre-existing packages.

(e.g. sshtunnel without the `-` is an OpenWRT package: https://github.com/openwrt/packages/tree/master/net/sshtunnel)

ssh-legion may be better, as it describes how this package is designed for many devices, not just one.